### PR TITLE
feat: datetime format added as an option

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ Syncs playcounts, track ratings, loved tracks and last played date from MusicBee
 
 * `-f, --first` : runs sync for the first time: **add** MusicBee playcount to Navidrome playcount. If not used, playcount will be updated only if greater than Navidrome's one (see [Notes](#-notes)). 
 * `--csv <path>` : MusicBee CSV source file path. By default if not passed, will look for a file named `MusicBee_Export.csv` in the same folder as `musicbee-navidrome-sync.exe`
+* `--datetime-format <format>` : MusicBee CSV datetime format. Default: `"DD/MM/YYYY HH:mm"`. Use available formats from https://day.js.org/docs/en/display/format`
+
 
 ### albumsSync
 

--- a/index.js
+++ b/index.js
@@ -22,18 +22,16 @@ const commandLinesOptions = {
     flags: '-u, --user <user_name>',
     description: 'choose Navidrome username (by default if not used, the first user will be used)'
   },
+  datetimeFormat: {
+    flags: '--datetime-format <format>',
+    description: 'MusicBee CSV datetime format. Default: "DD/MM/YYYY HH:mm"',
+    defaultValue: 'DD/MM/YYYY HH:mm'
+  },
   verbose: {
     flags: '--verbose',
     description: 'verbose debugging'
   }
 };
-
-program
-  .name('musicbee-navidrome-sync')
-  .description(
-    'MusicBee to Navidrome Sync (MBNDS) : Tools to sync MusicBee DB to Navidrome DB\nhttps://github.com/rombat/musicbee-navidrome-sync'
-  )
-  .version(packageJson.version, '-v, --version', 'output the current version');
 
 program
   .command('fullSync')
@@ -43,7 +41,19 @@ program
   .option(commandLinesOptions.verbose.flags, commandLinesOptions.verbose.description)
   .option(commandLinesOptions.csv.flags, commandLinesOptions.description, commandLinesOptions.defaultValue)
   .option(commandLinesOptions.db.flags, commandLinesOptions.db.description, commandLinesOptions.db.defaultValue)
+  .option(
+    commandLinesOptions.datetimeFormat.flags,
+    commandLinesOptions.datetimeFormat.description,
+    commandLinesOptions.datetimeFormat.defaultValue
+  )
   .action(runAction);
+
+program
+  .name('musicbee-navidrome-sync')
+  .description(
+    'MusicBee to Navidrome Sync (MBNDS) : Tools to sync MusicBee DB to Navidrome DB\nhttps://github.com/rombat/musicbee-navidrome-sync'
+  )
+  .version(packageJson.version, '-v, --version', 'output the current version');
 
 program
   .command('albumsSync')

--- a/lib/handlers/MBNDSynchronizer.js
+++ b/lib/handlers/MBNDSynchronizer.js
@@ -71,6 +71,12 @@ class MBNDSynchronizer {
       throw new Error('DB file not found');
     }
 
+    if (options.datetimeFormat && !dayjs(dayjs().format(options.datetimeFormat), options.datetimeFormat).isValid()) {
+      throw new Error(
+        `Invalid datetime format : ${options.datetimeFormat}. Please use available formats from https://day.js.org/docs/en/display/format`
+      );
+    }
+
     this.backupDbFile();
 
     this.sequelize = await dbManager.init(paths.dbFilePath);
@@ -163,9 +169,9 @@ class MBNDSynchronizer {
           }
           return rating;
         },
-        dateAdded: item => (!!item?.trim() && dayjs(item).isValid() ? dayjs(item).utc() : null),
-        lastPlayed: item => (!!item?.trim() && dayjs(item).isValid() ? dayjs(item).utc() : null),
-        dateModified: item => (!!item?.trim() && dayjs(item).isValid() ? dayjs(item).utc() : null),
+        dateAdded: item => (dayjs(item, options.datetimeFormat).isValid() ? dayjs(item, options.datetimeFormat).utc() : null),
+        lastPlayed: item => (dayjs(item, options.datetimeFormat).isValid() ? dayjs(item, options.datetimeFormat).utc() : null),
+        dateModified: item => (dayjs(item, options.datetimeFormat).isValid() ? dayjs(item, options.datetimeFormat).utc() : null),
         love: item => (!!item?.trim() ? 1 : 0)
       }
     })

--- a/lib/handlers/MBNDSynchronizer.js
+++ b/lib/handlers/MBNDSynchronizer.js
@@ -163,9 +163,9 @@ class MBNDSynchronizer {
           }
           return rating;
         },
-        dateAdded: item => (dayjs(item, 'DD/MM/YYYY HH:mm').isValid() ? dayjs(item, 'DD/MM/YYYY HH:mm').utc() : null),
-        lastPlayed: item => (dayjs(item, 'DD/MM/YYYY HH:mm').isValid() ? dayjs(item, 'DD/MM/YYYY HH:mm').utc() : null),
-        dateModified: item => (dayjs(item, 'DD/MM/YYYY HH:mm').isValid() ? dayjs(item, 'DD/MM/YYYY HH:mm').utc() : null),
+        dateAdded: item => (dayjs(item).isValid() ? dayjs(item).utc() : null),
+        lastPlayed: item => (dayjs(item).isValid() ? dayjs(item).utc() : null),
+        dateModified: item => (dayjs(item).isValid() ? dayjs(item).utc() : null),
         love: item => (!!item.trim() ? 1 : 0)
       }
     })

--- a/lib/handlers/MBNDSynchronizer.js
+++ b/lib/handlers/MBNDSynchronizer.js
@@ -163,10 +163,10 @@ class MBNDSynchronizer {
           }
           return rating;
         },
-        dateAdded: item => (dayjs(item).isValid() ? dayjs(item).utc() : null),
-        lastPlayed: item => (dayjs(item).isValid() ? dayjs(item).utc() : null),
-        dateModified: item => (dayjs(item).isValid() ? dayjs(item).utc() : null),
-        love: item => (!!item.trim() ? 1 : 0)
+        dateAdded: item => (!!item?.trim() && dayjs(item).isValid() ? dayjs(item).utc() : null),
+        lastPlayed: item => (!!item?.trim() && dayjs(item).isValid() ? dayjs(item).utc() : null),
+        dateModified: item => (!!item?.trim() && dayjs(item).isValid() ? dayjs(item).utc() : null),
+        love: item => (!!item?.trim() ? 1 : 0)
       }
     })
       .preFileLine((fileLineString, lineIdx) => {

--- a/package.json
+++ b/package.json
@@ -1,13 +1,14 @@
 {
   "name": "musicbee-navidrome-sync",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "sync ratings and playcount from musicbee db to navidrome db",
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "fullSync": "node index.js fullSync",
     "albumsSync": "node index.js albumsSync",
-    "artistsSync": "node index.js artistsSync"
+    "artistsSync": "node index.js artistsSync",
+    "build": "pkg ."
   },
   "author": "rombat",
   "license": "GNU GPL V3.0",
@@ -28,6 +29,7 @@
   "pkg": {
     "assets": ["node_modules/**/*"],
     "targets": [ "node16-win-x64"],
-    "outputPath": "dist"
+    "outputPath": "dist",
+    "outputName": "musicbee-navidrome-sync"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "musicbee-navidrome-sync",
-  "version": "1.0.7",
+  "version": "1.1.0",
   "description": "sync ratings and playcount from musicbee db to navidrome db",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
it appears that MusicBee datetime format may vary, so this allows to pass [a valid format](https://day.js.org/docs/en/display/format) as an option for `fullSync` command. See readme for more details