### PR TITLE
fix: ann_id removed from DB schema in navidrome dev version

### DIFF
--- a/lib/handlers/MBNDSynchronizer.js
+++ b/lib/handlers/MBNDSynchronizer.js
@@ -1,7 +1,6 @@
 const fs = require('fs');
 const csv2json = require('csvtojson');
 const { Op } = require('sequelize');
-const { randomUUID } = require('crypto');
 const pLimit = require('p-limit');
 const camelCase = require('camelcase');
 const dayjs = require('dayjs');
@@ -250,7 +249,6 @@ class MBNDSynchronizer {
           let annotation = foundTrack?.trackAnnotation;
           if (!annotation) {
             annotation = Annotation.build({
-              ann_id: randomUUID(),
               item_type: 'media_file',
               user_id: user.id,
               item_id: foundTrack.id,
@@ -364,7 +362,6 @@ class MBNDSynchronizer {
             let annotation = album?.albumAnnotation;
             if (!annotation) {
               annotation = Annotation.build({
-                ann_id: randomUUID(),
                 item_type: 'album',
                 user_id: user.id,
                 item_id: album.id,
@@ -476,7 +473,6 @@ class MBNDSynchronizer {
           let annotation = artist?.artistAnnotation;
           if (!annotation) {
             annotation = Annotation.build({
-              ann_id: randomUUID(),
               item_type: 'artist',
               user_id: user.id,
               item_id: artist.id,

--- a/lib/handlers/MBNDSynchronizer.js
+++ b/lib/handlers/MBNDSynchronizer.js
@@ -1,6 +1,7 @@
 const fs = require('fs');
 const csv2json = require('csvtojson');
 const { Op } = require('sequelize');
+const { randomUUID } = require('crypto');
 const pLimit = require('p-limit');
 const camelCase = require('camelcase');
 const dayjs = require('dayjs');
@@ -39,7 +40,7 @@ class MBNDSynchronizer {
       dbFilePath: undefined
     };
     this.options = options;
-    this.limit = pLimit(500);
+    this.limit = pLimit(5000);
 
     process.on('SIGINT', async () => await this.restoreDbFile());
     process.on('SIGTERM', async () => await this.restoreDbFile());
@@ -248,13 +249,17 @@ class MBNDSynchronizer {
 
           let annotation = foundTrack?.trackAnnotation;
           if (!annotation) {
-            annotation = Annotation.build({
+            const record = {
               item_type: 'media_file',
               user_id: user.id,
               item_id: foundTrack.id,
               play_count: 0,
               starred: 0
-            });
+            };
+            if (Annotation.getAttributes().ann_id) {
+              record.ann_id = randomUUID();
+            }
+            annotation = Annotation.build(record);
           }
 
           const update = {};
@@ -283,6 +288,7 @@ class MBNDSynchronizer {
           if (!Object.keys(update).length) {
             return;
           }
+
           if (!foundTrack.trackAnnotation) {
             await annotation.save();
           }
@@ -361,13 +367,18 @@ class MBNDSynchronizer {
             }
             let annotation = album?.albumAnnotation;
             if (!annotation) {
-              annotation = Annotation.build({
+              const record = {
                 item_type: 'album',
                 user_id: user.id,
                 item_id: album.id,
                 play_count: 0,
                 starred: 0
-              });
+              };
+
+              if (Annotation.getAttributes().ann_id) {
+                record.ann_id = randomUUID();
+              }
+              annotation = Annotation.build(record);
             }
 
             const update = {};
@@ -472,13 +483,18 @@ class MBNDSynchronizer {
 
           let annotation = artist?.artistAnnotation;
           if (!annotation) {
-            annotation = Annotation.build({
+            const record = {
               item_type: 'artist',
               user_id: user.id,
               item_id: artist.id,
               play_count: 0,
               starred: 0
-            });
+            };
+
+            if (Annotation.getAttributes().ann_id) {
+              record.ann_id = randomUUID();
+            }
+            annotation = Annotation.build(record);
           }
           const update = {};
           const totalPlaycount = artist.tracks.reduce((acc, current) => {

--- a/lib/handlers/dbManager.js
+++ b/lib/handlers/dbManager.js
@@ -44,4 +44,7 @@ const createRelationships = sequelize => {
   Annotation.belongsTo(Track, { as: 'track', foreignKey: 'item_id' });
   Annotation.belongsTo(Album, { as: 'album', foreignKey: 'item_id' });
   Annotation.belongsTo(User, { as: 'user', foreignKey: 'user_id' });
+  // ann_id removed from navidrome DB schema in this commit: https://github.com/navidrome/navidrome/commit/47378c68828861751b9d1a05d3fc9b29ce8dd9f0
+  // Sequelize sets an id attribute by default as primary key, which is not needed in this case
+  Annotation.removeAttribute('id');
 };

--- a/lib/handlers/dbManager.js
+++ b/lib/handlers/dbManager.js
@@ -19,15 +19,22 @@ exports.init = async dbFilePath => {
     throw error;
   }
 
-  createRelationships(sequelize);
+  await createRelationships(sequelize);
 
   return sequelize;
 };
 
-const createRelationships = sequelize => {
+const createRelationships = async sequelize => {
+  // handling legacy Annotation schema (ann_id removed from navidrome DB schema in this commit: https://github.com/navidrome/navidrome/commit/47378c68828861751b9d1a05d3fc9b29ce8dd9f0)
+  const annotationTableSchema = await sequelize.getQueryInterface().describeTable('annotation');
+
   const Track = sequelize.define('Track', TrackDefinition.attributes, TrackDefinition.options);
   const Album = sequelize.define('Album', AlbumDefinition.attributes, AlbumDefinition.options);
-  const Annotation = sequelize.define('Annotation', AnnotationDefinition.attributes, AnnotationDefinition.options);
+  const Annotation = sequelize.define(
+    'Annotation',
+    AnnotationDefinition.getAttributes(annotationTableSchema),
+    AnnotationDefinition.options
+  );
   const Artist = sequelize.define('Artist', ArtistDefinition.attributes, ArtistDefinition.options);
   const User = sequelize.define('User', UserDefinition.attributes, UserDefinition.options);
 
@@ -44,7 +51,4 @@ const createRelationships = sequelize => {
   Annotation.belongsTo(Track, { as: 'track', foreignKey: 'item_id' });
   Annotation.belongsTo(Album, { as: 'album', foreignKey: 'item_id' });
   Annotation.belongsTo(User, { as: 'user', foreignKey: 'user_id' });
-  // ann_id removed from navidrome DB schema in this commit: https://github.com/navidrome/navidrome/commit/47378c68828861751b9d1a05d3fc9b29ce8dd9f0
-  // Sequelize sets an id attribute by default as primary key, which is not needed in this case
-  Annotation.removeAttribute('id');
 };

--- a/lib/models/Annotation.js
+++ b/lib/models/Annotation.js
@@ -1,32 +1,45 @@
 const { DataTypes } = require('sequelize');
 const dayjs = require('dayjs');
 
-exports.attributes = {
-  user_id: { type: DataTypes.STRING, allowNull: false, defaultValue: '' },
-  item_id: { type: DataTypes.STRING, allowNull: false, defaultValue: '' },
-  item_type: { type: DataTypes.STRING, allowNull: false, defaultValue: '' },
-  play_count: { type: DataTypes.INTEGER, allowNull: false, defaultValue: 0 },
-  play_date: {
-    type: DataTypes.STRING,
-    defaultValue: null,
-    set(value) {
-      const date = dayjs(value);
-      this.setDataValue('play_date', date.format('YYYY-MM-DD HH:mm:ss'));
+exports.getAttributes = existingSchema => {
+  const defaultAttributes = {
+    ann_id: { type: DataTypes.STRING, primaryKey: true, allowNull: false },
+    user_id: { type: DataTypes.STRING, allowNull: false, defaultValue: '', primaryKey: true },
+    item_id: { type: DataTypes.STRING, allowNull: false, defaultValue: '', primaryKey: true },
+    item_type: { type: DataTypes.STRING, allowNull: false, defaultValue: '', primaryKey: true },
+    play_count: { type: DataTypes.INTEGER, allowNull: false, defaultValue: 0 },
+    play_date: {
+      type: DataTypes.STRING,
+      defaultValue: null,
+      set(value) {
+        const date = dayjs(value);
+        this.setDataValue('play_date', date.format('YYYY-MM-DD HH:mm:ss'));
+      }
+    },
+    rating: { type: DataTypes.INTEGER, allowNull: false, defaultValue: 0, validate: { min: 0, max: 5 } },
+    starred: { type: DataTypes.BOOLEAN, allowNull: false, defaultValue: false },
+    starred_at: {
+      type: DataTypes.STRING,
+      defaultValue: null,
+      set(value) {
+        const date = dayjs(value);
+        this.setDataValue('starred_at', date.isValid() ? date.format('YYYY-MM-DD HH:mm:ss') : null);
+      }
     }
-  },
-  rating: { type: DataTypes.INTEGER, allowNull: false, defaultValue: 0, validate: { min: 0, max: 5 } },
-  starred: { type: DataTypes.BOOLEAN, allowNull: false, defaultValue: false },
-  starred_at: {
-    type: DataTypes.STRING,
-    defaultValue: null,
-    set(value) {
-      const date = dayjs(value);
-      this.setDataValue('starred_at', date.isValid() ? date.format('YYYY-MM-DD HH:mm:ss') : null);
-    }
+  };
+  if (!existingSchema.ann_id) {
+    delete defaultAttributes.ann_id;
   }
+  return defaultAttributes;
 };
 
 exports.options = {
   tableName: 'annotation',
-  timestamps: false
+  timestamps: false,
+  indexes: [
+    {
+      fields: ['user_id', 'item_id', 'item_type'],
+      unique: true
+    }
+  ]
 };

--- a/lib/models/Annotation.js
+++ b/lib/models/Annotation.js
@@ -2,7 +2,6 @@ const { DataTypes } = require('sequelize');
 const dayjs = require('dayjs');
 
 exports.attributes = {
-  ann_id: { type: DataTypes.STRING, primaryKey: true, allowNull: false },
   user_id: { type: DataTypes.STRING, allowNull: false, defaultValue: '' },
   item_id: { type: DataTypes.STRING, allowNull: false, defaultValue: '' },
   item_type: { type: DataTypes.STRING, allowNull: false, defaultValue: '' },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "musicbee-navidrome-sync",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "musicbee-navidrome-sync",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "GNU GPL V3.0",
       "dependencies": {
         "camelcase": "^6.3.0",
@@ -20,6 +20,9 @@
       },
       "bin": {
         "musicbee-navidrome-sync": "index.js"
+      },
+      "devDependencies": {
+        "prettier": "^3.3.3"
       },
       "engines": {
         "node": ">=16.0.0"
@@ -959,6 +962,21 @@
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.5.0.tgz",
       "integrity": "sha512-r5o/V/ORTA6TmUnyWZR9nCj1klXCO2CEKNRlVuJptZe85QuhFayC7WeMic7ndayT5IRIR0S0xFxFi2ousartlQ=="
+    },
+    "node_modules/prettier": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.3.3.tgz",
+      "integrity": "sha512-i2tDNA0O5IrMO757lfrdQZCc2jPNDVntV0m/+4whiDfWaTKfMNgR7Qz0NAeGz/nRqF4m5/6CLzbP4/liHt12Ew==",
+      "dev": true,
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
     },
     "node_modules/promise-inflight": {
       "version": "1.0.1",
@@ -2111,6 +2129,12 @@
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.5.0.tgz",
       "integrity": "sha512-r5o/V/ORTA6TmUnyWZR9nCj1klXCO2CEKNRlVuJptZe85QuhFayC7WeMic7ndayT5IRIR0S0xFxFi2ousartlQ=="
+    },
+    "prettier": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.3.3.tgz",
+      "integrity": "sha512-i2tDNA0O5IrMO757lfrdQZCc2jPNDVntV0m/+4whiDfWaTKfMNgR7Qz0NAeGz/nRqF4m5/6CLzbP4/liHt12Ew==",
+      "dev": true
     },
     "promise-inflight": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -27,9 +27,16 @@
   },
   "bin": "index.js",
   "pkg": {
-    "assets": ["node_modules/**/*"],
-    "targets": [ "node16-win-x64"],
+    "assets": [
+      "node_modules/**/*"
+    ],
+    "targets": [
+      "node16-win-x64"
+    ],
     "outputPath": "dist",
     "outputName": "musicbee-navidrome-sync"
+  },
+  "devDependencies": {
+    "prettier": "^3.3.3"
   }
 }


### PR DESCRIPTION
`ann_id` column was removed from navidrome DB schema in annotation table in this commit: https://github.com/navidrome/navidrome/commit/47378c68828861751b9d1a05d3fc9b29ce8dd9f0

This PR handle both old and new DB schema